### PR TITLE
Fix/#51 정책 수정

### DIFF
--- a/src/apis/ActivityReport/policy.ts
+++ b/src/apis/ActivityReport/policy.ts
@@ -1,6 +1,7 @@
 import {
   PromiseInformation,
   PromiseListResponse,
+  PromiseResponseInformation,
 } from "@/types/ActivityReport/policy";
 import { api } from "..";
 // ------------- {{ 정책 카테고리 }} ------------------------
@@ -64,6 +65,14 @@ export async function deletePromise(promiseId: number): Promise<{}> {
 }
 
 // 공약 수정
-export async function putPromise(promiseId: number): Promise<{}> {
-  return await api.put(`/api/v1/promise/${promiseId}}`);
+export async function putPromise(
+  promise: PromiseResponseInformation
+): Promise<{}> {
+  const body = {
+    title: promise.title,
+    content: promise.content,
+    progress: promise.progress,
+  };
+  console.log(promise, body);
+  return await api.put(`/api/v1/promise/${promise.promiseCategoryId}`, body);
 }

--- a/src/apis/ActivityReport/policy.ts
+++ b/src/apis/ActivityReport/policy.ts
@@ -73,6 +73,5 @@ export async function putPromise(
     content: promise.content,
     progress: promise.progress,
   };
-  console.log(promise, body);
   return await api.put(`/api/v1/promise/${promise.promiseCategoryId}`, body);
 }

--- a/src/components/ActivityReport/PolicyList/NewPolicyPromiseItem.tsx
+++ b/src/components/ActivityReport/PolicyList/NewPolicyPromiseItem.tsx
@@ -63,7 +63,11 @@ const NewPolicyPromiseItem: React.FC<NewPolicyPromiseItemProps> = ({
     <S.Container>
       <S.ButtonContainer>
         <DeleteButton onClick={onCancel} />
-        <SubmitButton onClick={handleSubmit} />
+        <SubmitButton
+          onClick={handleSubmit}
+          isM70={promise.title === "" || promise.content === ""}
+          disabled={promise.title === "" || promise.content === ""}
+        />
       </S.ButtonContainer>
 
       <S.PromiseContainer>

--- a/src/components/ActivityReport/PolicyList/PolicyPromiseItem.tsx
+++ b/src/components/ActivityReport/PolicyList/PolicyPromiseItem.tsx
@@ -58,8 +58,9 @@ const PolicyPromiseItem: React.FC<PolicyPromiseItemProps> = ({ item }) => {
   };
 
   const handlePutPromise = () => {
+    const body = {};
     putPromise(
-      { promiseId: promise.promiseCategoryId },
+      { promise: promise },
       {
         onSuccess: () => {
           navigator(0);

--- a/src/components/ActivityReport/PolicyList/PolicyPromiseItem.tsx
+++ b/src/components/ActivityReport/PolicyList/PolicyPromiseItem.tsx
@@ -77,7 +77,11 @@ const PolicyPromiseItem: React.FC<PolicyPromiseItemProps> = ({ item }) => {
         {isFix ? (
           <>
             <DeleteButton onClick={handleDeletePromise} />
-            <SubmitButton onClick={handlePutPromise} />
+            <SubmitButton
+              onClick={handlePutPromise}
+              isM70={promise.title === "" || promise.content === ""}
+              disabled={promise.title === "" || promise.content === ""}
+            />
           </>
         ) : (
           <FixButton onClick={() => setIsFix(true)} />

--- a/src/components/ActivityReport/PolicyList/PolicyPromiseItem.tsx
+++ b/src/components/ActivityReport/PolicyList/PolicyPromiseItem.tsx
@@ -58,7 +58,6 @@ const PolicyPromiseItem: React.FC<PolicyPromiseItemProps> = ({ item }) => {
   };
 
   const handlePutPromise = () => {
-    const body = {};
     putPromise(
       { promise: promise },
       {

--- a/src/components/ActivityReport/PolicyList/PolicyPromiseItem.tsx
+++ b/src/components/ActivityReport/PolicyList/PolicyPromiseItem.tsx
@@ -71,8 +71,6 @@ const PolicyPromiseItem: React.FC<PolicyPromiseItemProps> = ({ item }) => {
     );
   };
 
-  console.log(promise.content);
-
   return (
     <S.Container>
       <S.ButtonContainer>

--- a/src/components/ActivityReport/PolicyList/PolicyPromiseItem.tsx
+++ b/src/components/ActivityReport/PolicyList/PolicyPromiseItem.tsx
@@ -71,6 +71,8 @@ const PolicyPromiseItem: React.FC<PolicyPromiseItemProps> = ({ item }) => {
     );
   };
 
+  console.log(promise.content);
+
   return (
     <S.Container>
       <S.ButtonContainer>

--- a/src/components/common/Button/SubmitButton.tsx
+++ b/src/components/common/Button/SubmitButton.tsx
@@ -3,11 +3,16 @@ import * as S from "@/styles/common/Button/SubmitButtonStyle";
 interface SubmitButtonProps {
   onClick: () => void;
   isM70?: boolean;
+  disabled?: boolean;
 }
 
-const SubmitButton: React.FC<SubmitButtonProps> = ({ onClick, isM70 }) => {
+const SubmitButton: React.FC<SubmitButtonProps> = ({
+  onClick,
+  isM70,
+  disabled,
+}) => {
   return (
-    <S.Container onClick={onClick} $isM70={isM70}>
+    <S.Container onClick={disabled ? undefined : onClick} $isM70={isM70}>
       <S.Text>등록</S.Text>
     </S.Container>
   );

--- a/src/hooks/activityReport/usePromise.ts
+++ b/src/hooks/activityReport/usePromise.ts
@@ -13,6 +13,7 @@ import {
 import {
   PromiseInformation,
   PromiseListResponse,
+  PromiseResponseInformation,
 } from "@/types/ActivityReport/policy";
 
 // ------------- {{ 정책 공약 }} ------------------------
@@ -43,7 +44,7 @@ export function useDeletePromise() {
 }
 
 export function usePutPromise() {
-  return useMutation<{}, Error, { promiseId: number }>({
-    mutationFn: ({ promiseId }) => putPromise(promiseId),
+  return useMutation<{}, Error, { promise: PromiseResponseInformation }>({
+    mutationFn: ({ promise }) => putPromise(promise),
   });
 }

--- a/src/styles/ActivityReport/PolicyList/PolicyPromiseItemStyle.ts
+++ b/src/styles/ActivityReport/PolicyList/PolicyPromiseItemStyle.ts
@@ -39,6 +39,7 @@ export const Promise = styled.p`
   font: var(--PC_InputText);
   color: var(--Primary);
   background-color: var(--M5);
+  word-wrap: break-word;
 `;
 
 export const PromiseInput = styled.input`

--- a/src/styles/ActivityReport/PolicyList/PolicyPromiseItemStyle.ts
+++ b/src/styles/ActivityReport/PolicyList/PolicyPromiseItemStyle.ts
@@ -40,6 +40,7 @@ export const Promise = styled.p`
   color: var(--Primary);
   background-color: var(--M5);
   word-wrap: break-word;
+  white-space: pre-line;
 `;
 
 export const PromiseInput = styled.input`


### PR DESCRIPTION
## 🌏 Summary
<!-- 어떤 내용의 PR인가요? -->

>  정책 수정

## ✨ Work Detail
<!-- 작업 내용을 적어주세요 -->

- [x]  공약 카테고리 전체 삭제 안됨- 삭제 확인 모달에서 ‘확인했습니다’ 입력 후 확인 버튼 클릭 시 반응 없음,  하위 공약이 하나도 없으면 삭제가능
- [x]  하위 공약 상세 내용 관리자 페이지에 입력한 텍스트가 학생용에 그대로 보이지 않습니다. (문장 줄 바꿈)
- [x]  공약 필드에 아무것도 입력 되어 있지 않을 시 등록 버튼 비활성화 처리
- [x]  공약 수정 시 등록 버튼 반응 없음, 입력은 다 가능한데 등록이 안됨
- [x]  일정 숫자가 넘어가면 글자 영역을 넘어서 작성되는데 한글일 경우는 해당사항 없습니다
- [x]  404에러

## 📚 Comment
<!-- 전달하고 싶은 내용이 있다면 적어주세요 -->

> 
